### PR TITLE
Initial implementation of a @_cdecl attribute to export top-level fun…

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -239,6 +239,9 @@ SIMPLE_DECL_ATTR(indirect, Indirect,
 SIMPLE_DECL_ATTR(warn_unqualified_access, WarnUnqualifiedAccess,
                  OnFunc /*| OnVar*/ | LongAttribute, 61)
 
+DECL_ATTR(_cdecl, CDecl,
+          OnFunc | LongAttribute | UserInaccessible, 62)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -571,6 +571,24 @@ public:
   }
 };
 
+/// Defines the @_cdecl attribute.
+class CDeclAttr : public DeclAttribute {
+public:
+  CDeclAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range, bool Implicit)
+    : DeclAttribute(DAK_CDecl, AtLoc, Range, Implicit),
+      Name(Name) {}
+
+  CDeclAttr(StringRef Name, bool Implicit)
+    : CDeclAttr(Name, SourceLoc(), SourceRange(), /*Implicit=*/true) {}
+
+  /// The symbol name.
+  const StringRef Name;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_CDecl;
+  }
+};
+
 /// Defines the @_semantics attribute.
 class SemanticsAttr : public DeclAttribute {
 public:

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -742,6 +742,14 @@ ERROR(no_objc_tagged_pointer_not_class_protocol,sema_tcd,none,
 ERROR(swift_native_objc_runtime_base_not_on_root_class,sema_tcd,none,
       "@_swift_native_objc_runtime_base_not_on_root_class can only be applied "
       "to root classes", ())
+
+ERROR(cdecl_not_at_top_level,sema_tcd,none,
+      "@_cdecl can only be applied to global functions", ())
+ERROR(cdecl_empty_name,sema_tcd,none,
+      "@_cdecl symbol name cannot be empty", ())
+ERROR(cdecl_throws,sema_tcd,none,
+      "raising errors from @_cdecl functions is not supported", ())
+
 ERROR(attr_methods_only,sema_tcd,none,
       "only methods can be declared %0", (DeclAttribute))
 ERROR(access_control_in_protocol,sema_tcd,none,
@@ -2344,7 +2352,7 @@ ERROR(objc_name_func_mismatch,sema_objc,none,
       (bool, unsigned, bool, unsigned, bool, bool))
 
 // If you change this, also change enum ObjCReason
-#define OBJC_ATTR_SELECT "select{marked dynamic|marked @objc|marked @IBOutlet|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override}"
+#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @IBOutlet|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override}"
 
 ERROR(objc_invalid_on_var,sema_objc,none,
       "property cannot be %" OBJC_ATTR_SELECT "0 "

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -42,7 +42,7 @@ const unsigned char MODULE_DOC_SIGNATURE[] = { 0xE2, 0x9C, 0xA8, 0x07 };
 
 /// Serialized module format major version number.
 ///
-/// Always 0 for Swift 1.0.
+/// Always 0 for Swift 1.x and 2.x.
 const uint16_t VERSION_MAJOR = 0;
 
 /// Serialized module format minor version number.
@@ -51,7 +51,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// To ensure that two separate changes don't silently get merged into one
 /// in source control, you should also update the comment to briefly
 /// describe what change you made.
-const uint16_t VERSION_MINOR = 222; // Last change: @_fixed_layout
+const uint16_t VERSION_MINOR = 223; // Last change: @_cdecl
 
 using DeclID = Fixnum<31>;
 using DeclIDField = BCFixed<31>;
@@ -1203,6 +1203,13 @@ namespace decls_block {
     BCFixed<1>, // implicit flag
     BCBlob      // _silgen_name
   >;
+
+  using CDeclDeclAttrLayout = BCRecordLayout<
+    CDecl_DECL_ATTR,
+    BCFixed<1>, // implicit flag
+    BCBlob      // _silgen_name
+  >;
+
   
   using AlignmentDeclAttrLayout = BCRecordLayout<
     Alignment_DECL_ATTR,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1875,7 +1875,10 @@ void AbstractFunctionDecl::setForeignErrorConvention(
 
 Optional<ForeignErrorConvention>
 AbstractFunctionDecl::getForeignErrorConvention() const {
-  if (!isObjC() || !isBodyThrowing()) return None;
+  if (!isObjC() && !getAttrs().hasAttribute<CDeclAttr>())
+    return None;
+  if (!isBodyThrowing())
+    return None;
   auto &conventionsMap = getASTContext().Impl.ForeignErrorConventions;
   auto it = conventionsMap.find(this);
   if (it == conventionsMap.end()) return None;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -327,6 +327,11 @@ void DeclAttribute::print(ASTPrinter &Printer,
     if (cast<AutoClosureAttr>(this)->isEscaping())
       Printer << "(escaping)";
     break;
+      
+  case DAK_CDecl:
+    Printer << "@_cdecl(\"" << cast<CDeclAttr>(this)->Name << "\")";
+    break;
+
   case DAK_ObjC: {
     if (Options.PrintForSIL && isImplicit())
       break;
@@ -421,6 +426,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "_silgen_name";
   case DAK_Alignment:
     return "_alignment";
+  case DAK_CDecl:
+    return "_cdecl";
   case DAK_SwiftNativeObjCRuntimeBase:
     return "_swift_native_objc_runtime_base";
   case DAK_Semantics:

--- a/lib/AST/Verifier.cpp
+++ b/lib/AST/Verifier.cpp
@@ -2249,8 +2249,9 @@ struct ASTNodeBase {};
         abort();
       }
 
-      if (AFD->getForeignErrorConvention() && !AFD->isObjC()) {
-        Out << "foreign error convention on non-@objc function\n";
+      if (AFD->getForeignErrorConvention()
+          && !AFD->isObjC() && !AFD->getAttrs().hasAttribute<CDeclAttr>()) {
+        Out << "foreign error convention on non-@objc, non-@_cdecl function\n";
         AFD->dump(Out);
         abort();
       }

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -220,7 +220,7 @@ void LinkEntity::mangle(raw_ostream &buffer) const {
 
   //   entity ::= declaration                     // other declaration
   case Kind::Function:
-    // As a special case, functions can have external asm names.
+    // As a special case, functions can have manually mangled names.
     if (auto AsmA = getDecl()->getAttrs().getAttribute<SILGenNameAttr>()) {
       buffer << AsmA->Name;
       return;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -563,6 +563,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     break;
   }
 
+  case DAK_CDecl:
   case DAK_SILGenName: {
     if (!consumeIf(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
@@ -599,9 +600,16 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       diagnose(Loc, diag::attr_only_at_non_local_scope, AttrName);
     }
 
-    if (!DiscardAttribute)
-      Attributes.add(new (Context) SILGenNameAttr(AsmName.getValue(), AtLoc,
+    if (!DiscardAttribute) {
+      if (DK == DAK_SILGenName)
+        Attributes.add(new (Context) SILGenNameAttr(AsmName.getValue(), AtLoc,
+                                                AttrRange, /*Implicit=*/false));
+      else if (DK == DAK_CDecl)
+        Attributes.add(new (Context) CDeclAttr(AsmName.getValue(), AtLoc,
                                                AttrRange, /*Implicit=*/false));
+      else
+        llvm_unreachable("out of sync with switch");
+    }
 
     break;
   }

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -89,7 +89,8 @@ static Identifier getNameForObjC(const NominalTypeDecl *NTD,
 namespace {
 class ObjCPrinter : private DeclVisitor<ObjCPrinter>,
                     private TypeVisitor<ObjCPrinter, void, 
-                                        Optional<OptionalTypeKind>> {
+                                        Optional<OptionalTypeKind>>
+{
   friend ASTVisitor;
   friend TypeVisitor;
 
@@ -118,7 +119,8 @@ public:
   }
 
   bool shouldInclude(const ValueDecl *VD) {
-    return VD->isObjC() && VD->getFormalAccess() >= minRequiredAccess &&
+    return (VD->isObjC() || VD->getAttrs().hasAttribute<CDeclAttr>()) &&
+      VD->getFormalAccess() >= minRequiredAccess &&
       !(isa<ConstructorDecl>(VD) && 
         cast<ConstructorDecl>(VD)->hasStubImplementation());
   }
@@ -306,8 +308,33 @@ private:
     return true;
   }
 
-  void printAbstractFunction(AbstractFunctionDecl *AFD, bool isClassMethod,
-                             bool isNSUIntegerSubscript = false) {
+  Type getForeignResultType(AbstractFunctionDecl *AFD,
+                            FunctionType *methodTy,
+                            Optional<ForeignErrorConvention> errorConvention) {
+    // A foreign error convention can affect the result type as seen in
+    // Objective-C.
+    if (errorConvention) {
+      switch (errorConvention->getKind()) {
+      case ForeignErrorConvention::ZeroResult:
+      case ForeignErrorConvention::NonZeroResult:
+        // The error convention provides the result type.
+        return errorConvention->getResultType();
+
+      case ForeignErrorConvention::NilResult:
+        // Errors are propagated via 'nil' returns.
+        return OptionalType::get(methodTy->getResult());
+
+      case ForeignErrorConvention::NonNilError:
+      case ForeignErrorConvention::ZeroPreservedResult:
+        break;
+      }
+    }
+    return methodTy->getResult();
+  }
+                                          
+  void printAbstractFunctionAsMethod(AbstractFunctionDecl *AFD,
+                                     bool isClassMethod,
+                                     bool isNSUIntegerSubscript = false) {
     printDocumentationComment(AFD);
     if (isClassMethod)
       os << "+ (";
@@ -322,32 +349,11 @@ private:
       }
     }
 
-    Type rawMethodTy = AFD->getType()->castTo<AnyFunctionType>()->getResult();
-    auto methodTy = rawMethodTy->castTo<FunctionType>();
-
-    // A foreign error convention can affect the result type as seen in
-    // Objective-C.
     Optional<ForeignErrorConvention> errorConvention
       = AFD->getForeignErrorConvention();
-    Type resultTy = methodTy->getResult();
-    if (errorConvention) {
-      switch (errorConvention->getKind()) {
-      case ForeignErrorConvention::ZeroResult:
-      case ForeignErrorConvention::NonZeroResult:
-        // The error convention provides the result type.
-        resultTy = errorConvention->getResultType();
-        break;
-
-      case ForeignErrorConvention::NilResult:
-        // Errors are propagated via 'nil' returns.
-        resultTy = OptionalType::get(resultTy);
-        break;
-
-      case ForeignErrorConvention::NonNilError:
-      case ForeignErrorConvention::ZeroPreservedResult:
-        break;
-      }
-    }
+    Type rawMethodTy = AFD->getType()->castTo<AnyFunctionType>()->getResult();
+    auto methodTy = rawMethodTy->castTo<FunctionType>();
+    auto resultTy = getForeignResultType(AFD, methodTy, errorConvention);
 
     // Constructors and methods returning DynamicSelf return
     // instancetype.    
@@ -457,15 +463,73 @@ private:
 
     os << ";\n";
   }
+  
+  void printSingleFunctionParam(const Pattern *param) {
+    // The type name may be multi-part.
+    PrintMultiPartType multiPart(*this);
+    visitPart(param->getType(), OTK_None);
+    if (isa<AnyPattern>(param))
+      return;
+    
+    os << ' ';
+    
+    Identifier name = cast<NamedPattern>(param)->getBodyName();
+    os << name;
+    if (isClangKeyword(name))
+      os << "_";
+  }
 
+  void printAbstractFunctionAsFunction(FuncDecl *FD) {
+    printDocumentationComment(FD);
+    Optional<ForeignErrorConvention> errorConvention
+      = FD->getForeignErrorConvention();
+    auto resultTy = getForeignResultType(FD,
+                                         FD->getType()->castTo<FunctionType>(),
+                                         errorConvention);
+    
+    // The result type may be a partial function type we need to close
+    // up later.
+    PrintMultiPartType multiPart(*this);
+    visitPart(resultTy, OTK_None);
+    
+    assert(FD->getAttrs().hasAttribute<CDeclAttr>()
+           && "not a cdecl function");
+    
+    os << ' ' << FD->getAttrs().getAttribute<CDeclAttr>()->Name << '(';
+    
+    auto bodyPatterns = FD->getBodyParamPatterns();
+    assert(bodyPatterns.size() == 1 && "not a C-compatible func");
+
+    if (auto *paramParen = dyn_cast<ParenPattern>(bodyPatterns.back())) {
+      printSingleFunctionParam(paramParen->getSemanticsProvidingPattern());
+    } else if (auto *paramTuple = dyn_cast<TuplePattern>(bodyPatterns.back())) {
+      interleave(paramTuple->getElements(),
+                 [&](const TuplePatternElt &elt) {
+                   printSingleFunctionParam(elt.getPattern()
+                                              ->getSemanticsProvidingPattern());
+                 },
+                 [&]{ os << ", "; });
+    } else {
+      llvm_unreachable("invalid param pattern");
+    }
+    
+    os << ')';
+    
+    // Finish the result type.
+    multiPart.finish();
+    
+    os << ';';
+  }
+    
   void visitFuncDecl(FuncDecl *FD) {
-    assert(FD->getDeclContext()->isTypeContext() &&
-           "cannot handle free functions right now");
-    printAbstractFunction(FD, FD->isStatic());
+    if (FD->getDeclContext()->isTypeContext())
+      printAbstractFunctionAsMethod(FD, FD->isStatic());
+    else
+      printAbstractFunctionAsFunction(FD);
   }
 
   void visitConstructorDecl(ConstructorDecl *CD) {
-    printAbstractFunction(CD, false);
+    printAbstractFunctionAsMethod(CD, false);
   }
 
   bool maybePrintIBOutletCollection(Type ty) {
@@ -507,9 +571,9 @@ private:
 
     if (VD->isStatic()) {
       // Objective-C doesn't have class properties. Just print the accessors.
-      printAbstractFunction(VD->getGetter(), true);
+      printAbstractFunctionAsMethod(VD->getGetter(), true);
       if (auto setter = VD->getSetter())
-        printAbstractFunction(setter, true);
+        printAbstractFunctionAsMethod(setter, true);
       return;
     }
 
@@ -630,9 +694,9 @@ private:
       isNSUIntegerSubscript = isNSUInteger(indexParam->getType());
     }
 
-    printAbstractFunction(SD->getGetter(), false, isNSUIntegerSubscript);
+    printAbstractFunctionAsMethod(SD->getGetter(), false, isNSUIntegerSubscript);
     if (auto setter = SD->getSetter())
-      printAbstractFunction(setter, false, isNSUIntegerSubscript);
+      printAbstractFunctionAsMethod(setter, false, isNSUIntegerSubscript);
   }
 
   /// Visit part of a type, such as the base of a pointer type.
@@ -1148,6 +1212,33 @@ private:
                                  Optional<OptionalTypeKind> optionalKind) {
     visitPart(RST->getReferentType(), optionalKind);
   }
+  
+  /// RAII class for printing multi-part C types, such as functions and arrays.
+  class PrintMultiPartType {
+    ObjCPrinter &Printer;
+    decltype(ObjCPrinter::openFunctionTypes) savedFunctionTypes;
+    
+    PrintMultiPartType(const PrintMultiPartType &) = delete;
+  public:
+    PrintMultiPartType(ObjCPrinter &Printer)
+      : Printer(Printer) {
+      savedFunctionTypes.swap(Printer.openFunctionTypes);
+    }
+    
+    void finish() {
+      auto &openFunctionTypes = Printer.openFunctionTypes;
+      while (!openFunctionTypes.empty()) {
+        const FunctionType *openFunctionTy = openFunctionTypes.pop_back_val();
+        Printer.finishFunctionType(openFunctionTy);
+      }
+      openFunctionTypes = std::move(savedFunctionTypes);
+      savedFunctionTypes.clear();
+    }
+    
+    ~PrintMultiPartType() {
+      finish();
+    }
+  };
 
   /// Print a full type, optionally declaring the given \p name.
   ///
@@ -1159,18 +1250,10 @@ public:
              StringRef name = "") {
     PrettyStackTraceType trace(M.getASTContext(), "printing", ty);
 
-    decltype(openFunctionTypes) savedFunctionTypes;
-    savedFunctionTypes.swap(openFunctionTypes);
-
+    PrintMultiPartType multiPart(*this);
     visitPart(ty, optionalKind);
     if (!name.empty())
       os << ' ' << name;
-    while (!openFunctionTypes.empty()) {
-      const FunctionType *openFunctionTy = openFunctionTypes.pop_back_val();
-      finishFunctionType(openFunctionTy);
-    }
-
-    openFunctionTypes = std::move(savedFunctionTypes);
   }
 };
 
@@ -1458,6 +1541,14 @@ public:
     seenTypes[CD] = { EmissionState::Defined, true };
     forwardDeclareMemberTypes(CD->getMembers());
     printer.print(CD);
+    return true;
+  }
+  
+  bool writeFunc(const FuncDecl *FD) {
+    if (addImport(FD))
+      return true;
+
+    printer.print(FD);
     return true;
   }
 
@@ -1800,6 +1891,8 @@ public:
           success = writeProtocol(PD);
         else if (auto ED = dyn_cast<EnumDecl>(D))
           success = writeEnum(ED);
+        else if (auto ED = dyn_cast<FuncDecl>(D))
+          success = writeFunc(ED);
         else
           llvm_unreachable("unknown top-level ObjC value decl");
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -432,6 +432,14 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
     if (!Captures.empty())
       TopLevelSGF->B.createMarkFunctionEscape(AFD, Captures);
   }
+  
+  // If the declaration is exported as a C function, emit its native-to-foreign
+  // thunk too, if it wasn't already forced.
+  if (AFD->getAttrs().hasAttribute<CDeclAttr>()) {
+    auto thunk = SILDeclRef(AFD).asForeign();
+    if (!hasFunction(thunk))
+      emitNativeToForeignThunk(thunk);
+  }
 }
 
 void SILGenModule::emitFunction(FuncDecl *fd) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -47,6 +47,7 @@ public:
   bool visitDeclAttribute(DeclAttribute *A) = delete;
 
 #define IGNORED_ATTR(X) void visit##X##Attr(X##Attr *) {}
+  IGNORED_ATTR(CDecl)
   IGNORED_ATTR(SILGenName)
   IGNORED_ATTR(Available)
   IGNORED_ATTR(Convenience)
@@ -648,6 +649,8 @@ public:
 #undef IGNORED_ATTR
 
   void visitAvailableAttr(AvailableAttr *attr);
+  
+  void visitCDeclAttr(CDeclAttr *attr);
 
   void visitFinalAttr(FinalAttr *attr);
   void visitIBActionAttr(IBActionAttr *attr);
@@ -860,6 +863,18 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
     TC.diagnose(EnclosingDecl->getLoc(),
                 diag::availability_decl_more_than_enclosing_enclosing_here);
   }
+}
+
+void AttributeChecker::visitCDeclAttr(CDeclAttr *attr) {
+  // Only top-level func decls are currently supported.
+  if (D->getDeclContext()->isTypeContext())
+    TC.diagnose(attr->getLocation(),
+                diag::cdecl_not_at_top_level);
+  
+  // The name must not be empty.
+  if (attr->Name.empty())
+    TC.diagnose(attr->getLocation(),
+                diag::cdecl_empty_name);
 }
 
 void AttributeChecker::visitUnsafeNoObjCTaggedPointerAttr(

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -391,6 +391,7 @@ withoutContext(TypeResolutionOptions options) {
 /// the OBJC_ATTR_SELECT macro in DiagnosticsSema.def.
 enum class ObjCReason {
   DoNotDiagnose,
+  ExplicitlyCDecl,
   ExplicitlyDynamic,
   ExplicitlyObjC,
   ExplicitlyIBOutlet,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1797,6 +1797,14 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
         break;
       }
 
+      case decls_block::CDecl_DECL_ATTR: {
+        bool isImplicit;
+        serialization::decls_block::CDeclDeclAttrLayout::readRecord(
+            scratch, isImplicit);
+        Attr = new (ctx) CDeclAttr(blobData, isImplicit);
+        break;
+      }
+
       case decls_block::Alignment_DECL_ATTR: {
         bool isImplicit;
         unsigned alignment;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1560,7 +1560,16 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
                                       theAttr->Name);
     return;
   }
-  
+
+  case DAK_CDecl: {
+    auto *theAttr = cast<CDeclAttr>(DA);
+    auto abbrCode = DeclTypeAbbrCodes[CDeclDeclAttrLayout::Code];
+    CDeclDeclAttrLayout::emitRecord(Out, ScratchRecord, abbrCode,
+                                    theAttr->isImplicit(),
+                                    theAttr->Name);
+    return;
+  }
+
   case DAK_Alignment: {
     auto *theAlignment = cast<AlignmentAttr>(DA);
     auto abbrCode = DeclTypeAbbrCodes[AlignmentDeclAttrLayout::Code];

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -1,0 +1,30 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/cdecl.swiftmodule -parse -emit-objc-header-path %t/cdecl.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: FileCheck %s < %t/cdecl.h
+// RUN: %check-in-clang %t/cdecl.h
+// RUN: %check-in-clang -fno-modules %t/cdecl.h -include Foundation.h -include ctypes.h -include CoreFoundation.h
+
+// REQUIRES: objc_interop
+
+// CHECK-LABEL: /// What a nightmare!
+// CHECK-LABEL: double (^ __nonnull block_nightmare(float (^ __nonnull x)(NSInteger)))(char);
+
+/// What a nightmare!
+@_cdecl("block_nightmare")
+func block_nightmare(x: @convention(block) Int -> Float)
+  -> @convention(block) CChar -> Double { return { _ in 0 } }
+
+// CHECK-LABEL: void foo_bar(NSInteger x, NSInteger y);
+@_cdecl("foo_bar")
+func foo(x: Int, bar y: Int) {}
+
+// CHECK-LABEL: double (* __nonnull function_pointer_nightmare(float (* __nonnull x)(NSInteger)))(char);
+@_cdecl("function_pointer_nightmare")
+func function_pointer_nightmare(x: @convention(c) Int -> Float)
+  -> @convention(c) CChar -> Double { return { _ in 0 } }
+  
+// CHECK-LABEL: void has_keyword_arg_names(NSInteger auto_, NSInteger union_);
+@_cdecl("has_keyword_arg_names")
+func keywordArgNames(auto: Int, union: Int) {}

--- a/test/SILGen/cdecl.swift
+++ b/test/SILGen/cdecl.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-frontend -emit-silgen %s | FileCheck %s
+
+// CHECK-LABEL: sil hidden @pear : $@convention(c)
+// CHECK:         function_ref @_TF5cdecl5apple
+// CHECK-LABEL: sil hidden @_TF5cdecl5apple
+@_cdecl("pear")
+func apple(f: @convention(c) Int -> Int) {
+}
+
+// CHECK-LABEL: sil hidden @_TF5cdecl16forceCEntryPoint
+// CHECK:         function_ref @grapefruit
+func forceCEntryPoint() {
+  apple(orange)
+}
+
+// CHECK-LABEL: sil hidden @grapefruit : $@convention(c)
+// CHECK:         function_ref @_TF5cdecl6orange
+// CHECK-LABEL: sil hidden @_TF5cdecl6orange
+@_cdecl("grapefruit")
+func orange(x: Int) -> Int {
+  return x
+}
+
+// CHECK-LABEL: sil @cauliflower : $@convention(c)
+// CHECK:         function_ref @_TF5cdecl8broccoli
+// CHECK-LABEL: sil @_TF5cdecl8broccoli
+@_cdecl("cauliflower")
+public func broccoli(x: Int) -> Int {
+  return x
+}
+
+// CHECK-LABEL: sil private @collard_greens : $@convention(c)
+// CHECK:         function_ref @_TF5cdeclP[[PRIVATE:.*]]4kale
+// CHECK:       sil private @_TF5cdeclP[[PRIVATE:.*]]4kale
+@_cdecl("collard_greens")
+private func kale(x: Int) -> Int {
+  return x
+}
+
+/* TODO: Handle error conventions
+@_cdecl("vomits")
+func barfs() throws {}
+ */

--- a/test/attr/attr_cdecl.swift
+++ b/test/attr/attr_cdecl.swift
@@ -1,0 +1,55 @@
+// RUN: %target-parse-verify-swift
+
+@_cdecl("cdecl_foo") func foo(x: Int) -> Int { return x }
+
+@_cdecl("") // expected-error{{symbol name cannot be empty}}
+func emptyName(x: Int) -> Int { return x }
+
+@_cdecl("noBody")
+func noBody(x: Int) -> Int // expected-error{{expected '{' in body of function}}
+
+@_cdecl("property") // expected-error{{may only be used on 'func' declarations}}
+var property: Int
+
+var computed: Int {
+  @_cdecl("get_computed") get { return 0 }
+  @_cdecl("set_computed") set { return }
+}
+
+struct SwiftStruct { var x, y: Int }
+enum SwiftEnum { case A, B }
+@objc enum CEnum: Int { case A, B }
+
+@_cdecl("swiftStruct")
+func swiftStruct(x: SwiftStruct) {} // expected-error{{cannot be represented}} expected-note{{Swift struct}}
+
+@_cdecl("swiftEnum")
+func swiftEnum(x: SwiftEnum) {} // expected-error{{cannot be represented}} expected-note{{non-'@objc' enum}}
+
+@_cdecl("cEnum")
+func cEnum(x: CEnum) {}
+
+class Foo {
+  @_cdecl("Foo_foo") // expected-error{{can only be applied to global functions}}
+  func foo(x: Int) -> Int { return x }
+
+  @_cdecl("Foo_foo_2") // expected-error{{can only be applied to global functions}}
+  static func foo(x: Int) -> Int { return x }
+
+  @_cdecl("Foo_init") // expected-error{{may only be used on 'func'}}
+  init() {}
+
+  @_cdecl("Foo_deinit") // expected-error{{may only be used on 'func'}}
+  deinit {}
+}
+
+func hasNested() {
+  @_cdecl("nested") // expected-error{{can only be used in a non-local scope}}
+  func nested() { }
+}
+
+// TODO: Handle error conventions in SILGen for toplevel functions.
+@_cdecl("throwing") // expected-error{{raising errors from @_cdecl functions is not supported}}
+func throwing() throws { }
+
+// TODO: cdecl name collisions


### PR DESCRIPTION
…ctions to C.

There's an immediate need for this in the core libs, and we have most of the necessary pieces on hand to make it easy to implement. This is an unpolished initial implementation, with the following limitations, among others:

- It doesn't support bridging error conventions,
- It relies on ObjC interop,
- It doesn't check for symbol name collisions,
- It has an underscored name with required symbol name `@cdecl("symbol_name")`, awaiting official bikeshed painting.